### PR TITLE
NXP-27225: merge dirty properties received on suggestion op

### DIFF
--- a/nuxeo-ai-model/src/main/java/org/nuxeo/ai/model/serving/SuggestionOp.java
+++ b/nuxeo-ai-model/src/main/java/org/nuxeo/ai/model/serving/SuggestionOp.java
@@ -22,15 +22,18 @@ import static org.nuxeo.ai.pipes.services.JacksonUtil.MAPPER;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.nuxeo.ai.enrichment.EnrichmentMetadata;
 import org.nuxeo.ai.metadata.AIMetadata;
 import org.nuxeo.ai.metadata.LabelSuggestion;
-import org.nuxeo.ai.enrichment.EnrichmentMetadata;
 import org.nuxeo.ecm.automation.core.Constants;
 import org.nuxeo.ecm.automation.core.annotations.Context;
 import org.nuxeo.ecm.automation.core.annotations.Operation;
@@ -52,14 +55,14 @@ import org.nuxeo.ecm.core.io.registry.context.RenderingContext;
 import org.nuxeo.ecm.core.schema.types.Field;
 import org.nuxeo.ecm.core.schema.types.ListType;
 import org.nuxeo.ecm.core.schema.types.Schema;
+
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * Suggests metadata for the specified document.
  */
-@Operation(id = SuggestionOp.ID, category = Constants.CAT_DOCUMENT, label = "Ask for a suggestion.",
-        description = "Calls intelligent services on the provided document and returns suggested metadata.")
+@Operation(id = SuggestionOp.ID, category = Constants.CAT_DOCUMENT, label = "Ask for a suggestion.", description = "Calls intelligent services on the provided document and returns suggested metadata.")
 public class SuggestionOp {
 
     public static final String ID = "AI.Suggestion";
@@ -77,27 +80,40 @@ public class SuggestionOp {
     @Context
     protected MarshallerRegistry registry;
 
-    @Param(name = "document", description = "A document", required = false)
-    protected DocumentModel documentModel;
+    @Param(name = "updatedDocument", description = "Document with changes done on client side before saving", required = false)
+    protected DocumentModel updatedDocument;
 
     @Param(name = "references", description = "Should the entity references be resolved?", required = false)
     protected boolean references = false;
 
     @OperationMethod
-    public Blob run(DocumentModel doc) {
+    public Blob run(DocumentRef docRef) {
+        DocumentModel docModel = coreSession.getDocument(docRef);
+        return run(docModel);
+    }
 
-        List<EnrichmentMetadata> suggestions;
-        if (doc == null || (suggestions = modelServingService.predict(doc)) == null || suggestions.isEmpty()) {
+    @OperationMethod
+    public Blob run(DocumentModel doc) {
+        if (updatedDocument != null) {
+            Arrays.stream(doc.getSchemas())
+                  .flatMap(schema -> updatedDocument.getProperties(schema).entrySet().stream())
+                  .forEach(entry -> doc.setPropertyValue(entry.getKey(), (Serializable) entry.getValue()));
+        }
+
+        List<EnrichmentMetadata> suggestions = modelServingService.predict(doc);
+        if (suggestions == null || suggestions.isEmpty()) {
             return Blobs.createJSONBlob(EMPTY_JSON_LIST);
         }
 
         ByteArrayOutputStream outWriter = new ByteArrayOutputStream();
-        DocumentPropertyJsonWriter writer = references ? registry
-                .getInstance(RenderingContext.CtxBuilder.fetchInDoc("properties").get(),
-                             DocumentPropertyJsonWriter.class) : null;
+        DocumentPropertyJsonWriter writer = references
+                ? registry.getInstance(RenderingContext.CtxBuilder.fetchInDoc("properties").get(),
+                        DocumentPropertyJsonWriter.class)
+                : null;
         try (JsonGenerator jg = MAPPER.getFactory().createGenerator(outWriter)) {
             List<SuggestionsAsJson> suggestionsAsJson = suggestions.stream()
-                                                                   .map(metadata -> writeJson(metadata, doc, writer, outWriter, jg))
+                                                                   .map(metadata -> writeJson(metadata, doc, writer,
+                                                                           outWriter, jg))
                                                                    .filter(Objects::nonNull)
                                                                    .collect(Collectors.toList());
             return Blobs.createJSONBlob(MAPPER.writeValueAsString(suggestionsAsJson));
@@ -110,8 +126,7 @@ public class SuggestionOp {
      * Write property information alongside suggestions.
      */
     protected SuggestionsAsJson writeJson(EnrichmentMetadata metadata, DocumentModel input,
-                                          DocumentPropertyJsonWriter writer, ByteArrayOutputStream outWriter,
-                                          JsonGenerator jg) {
+            DocumentPropertyJsonWriter writer, ByteArrayOutputStream outWriter, JsonGenerator jg) {
         try {
             List<SuggestionListAsJson> suggestionList = new ArrayList<>();
             for (LabelSuggestion labelSuggestion : metadata.getLabels()) {
@@ -152,17 +167,6 @@ public class SuggestionOp {
             prop.setValue(label.getName());
         }
         return prop;
-    }
-
-    @OperationMethod
-    public Blob run(DocumentRef docRef) {
-        DocumentModel docModel = coreSession.getDocument(docRef);
-        return run(docModel);
-    }
-
-    @OperationMethod
-    public Blob run() {
-        return run(documentModel);
     }
 
     /**

--- a/nuxeo-ai-model/src/test/java/org/nuxeo/ai/model/serving/SuggestionOpTest.java
+++ b/nuxeo-ai-model/src/test/java/org/nuxeo/ai/model/serving/SuggestionOpTest.java
@@ -1,0 +1,243 @@
+/*
+ * (C) Copyright 2019 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nuno Cunha <ncunha@nuxeo.com>
+ */
+package org.nuxeo.ai.model.serving;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.nuxeo.ai.pipes.services.JacksonUtil.MAPPER;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.nuxeo.ai.enrichment.EnrichmentMetadata;
+import org.nuxeo.ai.enrichment.EnrichmentTestFeature;
+import org.nuxeo.ai.metadata.AIMetadata;
+import org.nuxeo.ai.metadata.LabelSuggestion;
+import org.nuxeo.ecm.automation.AutomationService;
+import org.nuxeo.ecm.automation.OperationContext;
+import org.nuxeo.ecm.automation.OperationException;
+import org.nuxeo.ecm.automation.test.AutomationFeature;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.DocumentNotFoundException;
+import org.nuxeo.ecm.core.api.IdRef;
+import org.nuxeo.ecm.core.api.impl.blob.JSONBlob;
+import org.nuxeo.ecm.platform.test.PlatformFeature;
+import org.nuxeo.runtime.mockito.MockitoFeature;
+import org.nuxeo.runtime.mockito.RuntimeService;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+/**
+ * Unit Tests the Suggestion Operation.
+ */
+@RunWith(FeaturesRunner.class)
+@Features({ EnrichmentTestFeature.class, PlatformFeature.class, AutomationFeature.class, MockitoFeature.class })
+@Deploy({ "org.nuxeo.ai.ai-core", "org.nuxeo.ai.ai-model", "org.nuxeo.ai.ai-model:OSGI-INF/model-serving-test.xml" })
+public class SuggestionOpTest {
+
+    @Inject
+    protected CoreSession session;
+
+    @Inject
+    protected AutomationService automationService;
+
+    @Mock
+    @RuntimeService
+    protected ModelServingService modelServingService;
+
+    protected OperationContext ctx;
+
+    protected DocumentModel documentModel;
+
+    @Before
+    public void setUp() {
+        documentModel = session.createDocumentModel("/", "My Doc", "FileRefDoc");
+        documentModel.setPropertyValue("dc:title", "my document");
+        documentModel.setPropertyValue("dc:description", "some description");
+        documentModel = session.createDocument(documentModel);
+        session.save();
+
+        ctx = new OperationContext(session);
+        ctx.setInput(documentModel);
+
+        when(modelServingService.predict(eq(documentModel))).thenReturn(getSamplePrediction());
+    }
+
+    @After
+    public void tearDown() {
+        ctx.close();
+    }
+
+    @Test(expected = OperationException.class)
+    public void shouldThrowExceptionWhenInputIsNull() throws OperationException {
+        ctx.setInput(null);
+        automationService.run(ctx, SuggestionOp.ID);
+    }
+
+    @Test(expected = DocumentNotFoundException.class)
+    public void shouldThrowExceptionWhenDocRefIsInvalid() throws OperationException {
+        ctx.setInput(new IdRef("invalidId"));
+        automationService.run(ctx, SuggestionOp.ID);
+    }
+
+    @Test
+    public void shouldNotPersistDocumentPropertiesWhenTheyAreProvided() throws OperationException {
+        DocumentModel updatedDocument = session.getDocument(documentModel.getRef());
+        updatedDocument.setPropertyValue("dc:description", "updated description here");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("updatedDocument", updatedDocument);
+
+        automationService.run(ctx, SuggestionOp.ID, parameters);
+
+        DocumentModel returnedDocument = session.getDocument(documentModel.getRef());
+        assertEquals("some description", returnedDocument.getPropertyValue("dc:description"));
+    }
+
+    @Test
+    public void shouldCallPredictionServiceWithMergedPropertiesWhenDocAlreadyExists() throws OperationException {
+        DocumentModel updatedDocument = session.getDocument(documentModel.getRef());
+        updatedDocument.setPropertyValue("dc:description", "updated description here");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("updatedDocument", updatedDocument);
+        
+        automationService.run(ctx, SuggestionOp.ID, parameters);
+
+        ArgumentCaptor<DocumentModel> argument = ArgumentCaptor.forClass(DocumentModel.class);
+        verify(modelServingService).predict(argument.capture());
+        assertEquals("my document", argument.getValue().getPropertyValue("dc:title"));
+        assertEquals("updated description here", argument.getValue().getPropertyValue("dc:description"));
+    }
+
+    @Test
+    public void shouldReturnEmptyJsonListWhenSuggestionsAreNull() throws OperationException {
+        DocumentModel doc = Mockito.mock(DocumentModel.class);
+        when(modelServingService.predict(eq(doc))).thenReturn(null);
+
+        OperationContext ctx = new OperationContext(session);
+        ctx.setInput(doc);
+        assertEmptyList((JSONBlob) automationService.run(ctx, SuggestionOp.ID));
+        verify(modelServingService).predict(eq(doc));
+    }
+
+    @Test
+    public void shouldReturnEmptyJsonListWhenSuggestionsAreEmpty() throws OperationException {
+        DocumentModel doc = Mockito.mock(DocumentModel.class);
+        when(modelServingService.predict(eq(doc))).thenReturn(Collections.emptyList());
+
+        OperationContext ctx = new OperationContext(session);
+        ctx.setInput(doc);
+        assertEmptyList((JSONBlob) automationService.run(ctx, SuggestionOp.ID));
+        verify(modelServingService).predict(eq(doc));
+    }
+
+    @Test
+    public void shouldReturnSimpleSuggestionListWhenNoReferencesParamIsPassed() throws OperationException, IOException {
+        assertSimpleSuggestionList((JSONBlob) automationService.run(ctx, SuggestionOp.ID));
+    }
+
+    @Test
+    public void shouldReturnResolvedSuggestionListWhenReferencesParamIsTrue() throws OperationException, IOException {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("references", true);
+
+        assertResolvedSuggestionList((JSONBlob) automationService.run(ctx, SuggestionOp.ID, parameters));
+    }
+
+    protected List<EnrichmentMetadata> getSamplePrediction() {
+        EnrichmentMetadata.Builder builder = new EnrichmentMetadata.Builder("/prediction/custommodel", "xyz",
+                Collections.emptySet(), "repoName", "docRef", Collections.emptySet());
+        builder.withLabels(List.of(
+                new LabelSuggestion("dr:docIdOnlyRef",
+                        List.of(new AIMetadata.Label("123456", 0.8528175f),
+                                new AIMetadata.Label("not_finding_this_one", 0.864372f))),
+                new LabelSuggestion("dc:creator",
+                        List.of(new AIMetadata.Label("me", 0.9528175f),
+                                new AIMetadata.Label("Administrator", 0.83437204f))),
+                new LabelSuggestion("dc:nature", List.of(new AIMetadata.Label("report", 0.83437204f))),
+                new LabelSuggestion("dc:subjects", List.of(new AIMetadata.Label("NO_MATCH", 0.8650408f),
+                        new AIMetadata.Label("music", 0.83437204f)))));
+
+        return List.of(builder.build());
+    }
+
+    protected void assertEmptyList(JSONBlob blob) {
+        assertEquals(SuggestionOp.EMPTY_JSON_LIST, blob.getString());
+    }
+
+    protected void assertSimpleSuggestionList(JSONBlob blob) throws IOException {
+        JsonNode jsonTree = MAPPER.readTree(blob.getString());
+        JsonNode suggestions = jsonTree.get(0).get("suggestions");
+        assertEquals(4, suggestions.size());
+        for (JsonNode suggestion : suggestions) {
+            List<JsonNode> asProperty = suggestion.get("values").findValues("value");
+            assertTrue(asProperty.stream().allMatch(n -> n instanceof TextNode));
+        }
+    }
+
+    protected void assertResolvedSuggestionList(JSONBlob blob) throws IOException {
+        JsonNode jsonTree = MAPPER.readTree(blob.getString());
+        JsonNode suggestions = jsonTree.get(0).get("suggestions");
+        assertEquals(4, suggestions.size());
+        for (JsonNode suggestion : suggestions) {
+            List<JsonNode> asProperty = suggestion.get("values").findValues("value");
+            Set<String> entityType = asProperty.stream()
+                                               .map(jsonNode -> jsonNode.get("entity-type"))
+                                               .filter(Objects::nonNull)
+                                               .map(JsonNode::asText)
+                                               .collect(Collectors.toSet());
+            switch (suggestion.get("property").asText()) {
+            case "dr:docIdOnlyRef":
+                assertFalse(entityType.contains("document"));
+                break;
+            case "dc:creator":
+                assertTrue(entityType.contains("user"));
+                break;
+            default:
+                assertTrue(entityType.contains("directoryEntry"));
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Disclaimer:
- Not sure if I have the correct formatter or not, but some of the code got reformatted. Please let me know if which formatter should I use;
- The second commit was an attempt to test the properties merge, which lead me to the need of using Mocks and ArgumentCaptors. In theory, by using that kind of approach the test will be unitary and not a kind of integration test. Still, please let me know if you have other approach for ensuring that the new code is properly tested;

Thanks!