### PR TITLE
NXBT-27350: increase version from 2.2.0-SNAPSHOT to 3.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ This repository provides 3 packages:
 | 2.0.1| 10.3  |
 | 2.1.0| 10.10 |
 | 2.1.1| 10.10-HF02 |
-| 2.1.2| 10.10-HF05, 11.1-SNAPSHOT |
-| 2.2.X| 11.1-SNAPSHOT |
+| 2.1.2| 10.10-HF05 |
+| 2.1.3| 10.10-HF22 |
+| 2.2.x| 10.10-HF23+ |
+| 2.3.x| 11.1-SNAPSHOT |
 
 1. Install the nuxeo-ai-core package. `./bin/nuxeoctl mp-install nuxeo-ai-core`
 

--- a/addons/nuxeo-ai-aws-core/pom.xml
+++ b/addons/nuxeo-ai-aws-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-aws-core</artifactId>
   <name>Nuxeo AI AWS Core</name>

--- a/addons/nuxeo-ai-aws-package/pom.xml
+++ b/addons/nuxeo-ai-aws-package/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-aws-package</artifactId>
   <packaging>zip</packaging>

--- a/addons/nuxeo-ai-image-quality-core/pom.xml
+++ b/addons/nuxeo-ai-image-quality-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-image-quality-core</artifactId>
   <name>Nuxeo AI image quality core</name>

--- a/addons/nuxeo-ai-image-quality-package/pom.xml
+++ b/addons/nuxeo-ai-image-quality-package/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nuxeo-ai-image-quality-package</artifactId>

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-addons</artifactId>
   <name>Nuxeo AI Addons parent POM</name>

--- a/nuxeo-ai-core-package/pom.xml
+++ b/nuxeo-ai-core-package/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nuxeo-ai-core-package</artifactId>

--- a/nuxeo-ai-core/pom.xml
+++ b/nuxeo-ai-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-core</artifactId>
   <name>Ai core</name>

--- a/nuxeo-ai-model/pom.xml
+++ b/nuxeo-ai-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-model</artifactId>
   <name>Ai custom models</name>

--- a/nuxeo-ai-pipes/pom.xml
+++ b/nuxeo-ai-pipes/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.nuxeo.ai</groupId>
   <artifactId>nuxeo-ai-pipes</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.nuxeo.ai</groupId>
   <artifactId>ai-core-parent</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>Ai core parent</name>
   <description>Nuxeo AI functionality</description>
   <packaging>pom</packaging>


### PR DESCRIPTION
Prepare release on `2.1_10.10` maintenance branch:
- increase major version from 2.2.0-SNAPSHOT to 3.0-SNAPSHOT on `master` (vs NXP 11.1-SNAPSHOT)
- will use 2.2.0-SNAPSHOT on maintenance branch (vs NXP 10.10-HF23-SNAPSHOT+)