### PR TITLE
10.10/fix INSIGHT-810 sprint version

### DIFF
--- a/addons/nuxeo-ai-aws-core/pom.xml
+++ b/addons/nuxeo-ai-aws-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-aws-core</artifactId>
   <name>Nuxeo AI AWS Core</name>

--- a/addons/nuxeo-ai-aws-package/pom.xml
+++ b/addons/nuxeo-ai-aws-package/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-aws-package</artifactId>
   <packaging>zip</packaging>

--- a/addons/nuxeo-ai-image-quality-core/pom.xml
+++ b/addons/nuxeo-ai-image-quality-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-image-quality-core</artifactId>
   <name>Nuxeo AI image quality core</name>

--- a/addons/nuxeo-ai-image-quality-package/pom.xml
+++ b/addons/nuxeo-ai-image-quality-package/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nuxeo-ai-image-quality-package</artifactId>

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-addons</artifactId>
   <name>Nuxeo AI Addons parent POM</name>

--- a/nuxeo-ai-config/pom.xml
+++ b/nuxeo-ai-config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-config</artifactId>
   <name>Nuxeo AI Config Module</name>

--- a/nuxeo-ai-core-package/pom.xml
+++ b/nuxeo-ai-core-package/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nuxeo-ai-core-package</artifactId>

--- a/nuxeo-ai-core/pom.xml
+++ b/nuxeo-ai-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-core</artifactId>
   <name>Ai core</name>

--- a/nuxeo-ai-model/pom.xml
+++ b/nuxeo-ai-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>nuxeo-ai-model</artifactId>
   <name>Ai custom models</name>

--- a/nuxeo-ai-pipes/pom.xml
+++ b/nuxeo-ai-pipes/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <groupId>org.nuxeo.ai</groupId>
   <artifactId>nuxeo-ai-pipes</artifactId>

--- a/nuxeo-ai-web-ui/pom.xml
+++ b/nuxeo-ai-web-ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.nuxeo.ai</groupId>
   <artifactId>ai-core-parent</artifactId>
-  <version>2.4.2-SNAPSHOT</version>
+  <version>2.5.0-SNAPSHOT</version>
   <name>Ai core parent</name>
   <description>Nuxeo AI functionality</description>
   <packaging>pom</packaging>


### PR DESCRIPTION
Set next sprint version to `2.5.0-SNAPSHOT` (master is `2.4.2-SNAPSHOT`)