### PR TITLE
feat: INSIGHT-786 install nuxeo-csv

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -194,12 +194,13 @@ reg rm "${DOCKER_REGISTRY}/${ORG}/${APP_NAME}:${VERSION}" || true
                 setGitHubBuildStatus('build/docker')
                 container('platform11') {
                     sh "cp nuxeo-ai-core-package/target/nuxeo-ai-core-*.zip docker/"
-                    withCredentials([usernameColonPassword(credentialsId: 'connect-preprod', variable: 'CONNECT_CREDS_PREPROD')]) {
-                        sh '''
-curl -fsSL -u "$CONNECT_CREDS_PREPROD" "$MARKETPLACE_URL_PREPROD/package/nuxeo-web-ui/download" -o docker/nuxeo-web-ui.zip
-'''
-                    }
                     withEnv(["PLATFORM_VERSION=${PLATFORM_VERSION}"]) {
+                        withCredentials([usernameColonPassword(credentialsId: 'connect-preprod', variable: 'CONNECT_CREDS_PREPROD')]) {
+                            sh '''
+curl -fsSL -u "$CONNECT_CREDS_PREPROD" "$MARKETPLACE_URL_PREPROD/package/nuxeo-web-ui/download" -o docker/nuxeo-web-ui.zip
+curl -fsSL -u "$CONNECT_CREDS_PREPROD" "$MARKETPLACE_URL_PREPROD/package/nuxeo-csv/download?version=$PLATFORM_VERSION" -o docker/nuxeo-csv.zip
+'''
+                        }
                         dir('docker') {
                             echo "Build preview image"
                             sh 'printenv|sort|grep VERSION'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,4 +20,5 @@ LABEL org.opencontainers.image.licenses="(C) Copyright 2020 Nuxeo (https://nuxeo
 
 COPY nuxeo-ai-core-*.zip /tmp/nuxeo-ai-core.zip
 COPY nuxeo-web-ui.zip /tmp/nuxeo-web-ui.zip
-RUN /install-packages.sh /tmp/nuxeo-ai-core.zip /tmp/nuxeo-web-ui.zip
+COPY nuxeo-csv.zip /tmp/nuxeo-csv.zip
+RUN /install-packages.sh /tmp/nuxeo-ai-core.zip /tmp/nuxeo-web-ui.zip /tmp/nuxeo-csv.zip


### PR DESCRIPTION
`nuxeo-csv not available on platform version server-11.4.34 (relax is not allowed)`
There is no compliant version on Connect PROD. Continuous releases are missing as of 11.4.x.:
```
11.3.56			server-11.3.56, server-11.3.56-*
11.4.0-SNAPSHOT 	server-11.4-SNAPSHOT
```

As a workaround the nuxeo-csv package is downloaded from PREPROD and installed at build time, like nuxeo-web-ui.