### PR TITLE
fix: INSIGHT-786 don't use project.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <description>Nuxeo AI functionality</description>
   <packaging>pom</packaging>
   <properties>
+    <nuxeo.ai.version>2.6.0-SNAPSHOT</nuxeo.ai.version>
     <tensorflow.version>1.11.0</tensorflow.version>
     <nuxeo.target.version>10.10</nuxeo.target.version>
     <wiremock.version>2.18.0</wiremock.version>
@@ -108,23 +109,23 @@
       <dependency>
         <groupId>org.nuxeo.ai</groupId>
         <artifactId>nuxeo-ai-pipes</artifactId>
-        <version>${project.version}</version>
+        <version>${nuxeo.ai.version}</version>
       </dependency>
       <dependency>
         <groupId>org.nuxeo.ai</groupId>
         <artifactId>nuxeo-ai-core</artifactId>
-        <version>${project.version}</version>
+        <version>${nuxeo.ai.version}</version>
       </dependency>
       <dependency>
         <groupId>org.nuxeo.ai</groupId>
         <artifactId>nuxeo-ai-core</artifactId>
         <type>test-jar</type>
-        <version>${project.version}</version>
+        <version>${nuxeo.ai.version}</version>
       </dependency>
       <dependency>
         <groupId>org.nuxeo.ai</groupId>
         <artifactId>nuxeo-ai-model</artifactId>
-        <version>${project.version}</version>
+        <version>${nuxeo.ai.version}</version>
       </dependency>
       <dependency>
         <groupId>org.nuxeo.elasticsearch</groupId>
@@ -135,12 +136,12 @@
       <dependency>
         <groupId>org.nuxeo.ai</groupId>
         <artifactId>nuxeo-ai-web-ui</artifactId>
-        <version>${project.version}</version>
+        <version>${nuxeo.ai.version}</version>
       </dependency>
       <dependency>
         <groupId>org.nuxeo.ai</groupId>
         <artifactId>nuxeo-ai-core-package</artifactId>
-        <version>${project.version}</version>
+        <version>${nuxeo.ai.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>


### PR DESCRIPTION
project.version prevent child project from having their own version, this breaks the inherited dependency management
