### PR TITLE
fix(AICORE-454): HF dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,7 @@ curl --retry 5 -fsSL "https://github.com/genuinetools/reg/releases/download/v0.1
 echo "\${REG_SHA256} /usr/bin/reg" | sha256sum -c - && chmod +x /usr/bin/reg
 """
                     script {
-                        PLATFORM_VERSION = sh(script: 'mvn help:evaluate -Dexpression=nuxeo.platform.version -q -DforceStdout', returnStdout: true).trim()
+                        PLATFORM_VERSION = sh(script: 'mvn help:evaluate -Dexpression=nuxeo.latest.version -q -DforceStdout', returnStdout: true).trim()
                         if (env.CHANGE_TARGET) {
                             echo "PR build: cleaning up the branch artifacts..."
                             sh """

--- a/addons/nuxeo-ai-aws-package/src/main/assemble/assembly.xml
+++ b/addons/nuxeo-ai-aws-package/src/main/assemble/assembly.xml
@@ -22,6 +22,7 @@
       <filterset>
         <filter token="VERSION" value="${maven.project.version}"/>
         <filter token="DISTRIB_VERSION" value="${nuxeo.target.version}"/>
+        <filter token="HF_VERSION" value="${nuxeo.distribution.version}"/>
       </filterset>
     </copy>
     <copy file="${outdir}/nuxeo-ai-aws-artifacts.properties" todir="${outdir}/marketplace/install"/>

--- a/addons/nuxeo-ai-aws-package/src/main/resources/package.xml
+++ b/addons/nuxeo-ai-aws-package/src/main/resources/package.xml
@@ -8,9 +8,6 @@
   <vendor>Nuxeo</vendor>
   <installer restart="true" />
   <uninstaller restart="true" />
-  <!-- <hotreload-support>false</hotreload-support> -->
-  <!-- <require-terms-and-conditions-acceptance>false</require-terms-and-conditions-acceptance> -->
-  <!-- Nuxeo Validation: none | inprocess | primary_validation | nuxeo_certified -->
   <nuxeo-validation>nuxeo_certified</nuxeo-validation>
   <!-- Production State: production_ready | testing | proto -->
   <production-state>production_ready</production-state>
@@ -19,22 +16,10 @@
     <platform>server-@DISTRIB_VERSION@</platform>
     <platform>server-@DISTRIB_VERSION@-HF*</platform>
   </platforms>
-  <!-- Dependencies on other packages -->
   <dependencies>
     <package>nuxeo-ai-core:@VERSION@:@VERSION@</package>
-    <!-- If you require JSF UI package:  -->
-    <!-- <package>nuxeo-jsf-ui</package> -->
-    <!-- If you require WEB UI package:  -->
-    <!-- <package>nuxeo-web-ui</package> -->
+    <package>nuxeo-@HF_VERSION@</package>
   </dependencies>
-  <!-- Conflicts with other packages -->
-  <!-- <conflicts> -->
-  <!-- <package>a-conflicting-package:1.0.0:1.0.0</package> -->
-  <!-- </conflicts> -->
-  <!-- Provides features of other packages -->
-  <!-- <provides> -->
-  <!-- <package>an-embedded-package:1.0.0:1.0.0</package> -->
-  <!-- </provides> -->
   <license>Apache License, Version 2.0</license>
   <license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
   <!-- Visibility: PRIVATE | MARKETPLACE | DEV | PUBLIC -->

--- a/addons/nuxeo-ai-gcp-package/src/main/assemble/assembly.xml
+++ b/addons/nuxeo-ai-gcp-package/src/main/assemble/assembly.xml
@@ -22,6 +22,7 @@
       <filterset>
         <filter token="VERSION" value="${maven.project.version}"/>
         <filter token="DISTRIB_VERSION" value="${nuxeo.target.version}"/>
+        <filter token="HF_VERSION" value="${nuxeo.distribution.version}"/>
       </filterset>
     </copy>
     <copy file="${outdir}/nuxeo-ai-gcp-artifacts.properties" todir="${outdir}/marketplace/install"/>

--- a/addons/nuxeo-ai-gcp-package/src/main/resources/package.xml
+++ b/addons/nuxeo-ai-gcp-package/src/main/resources/package.xml
@@ -16,9 +16,9 @@
     <platform>server-@DISTRIB_VERSION@</platform>
     <platform>server-@DISTRIB_VERSION@-HF*</platform>
   </platforms>
-  <!-- Dependencies on other packages -->
   <dependencies>
-    <package>nuxeo-ai-core:@VERSION@</package>
+    <package>nuxeo-ai-core:@VERSION@:@VERSION@</package>
+    <package>nuxeo-@HF_VERSION@</package>
   </dependencies>
   <license>Apache License, Version 2.0</license>
   <license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>

--- a/addons/nuxeo-ai-image-quality-package/src/main/assemble/assembly.xml
+++ b/addons/nuxeo-ai-image-quality-package/src/main/assemble/assembly.xml
@@ -22,6 +22,7 @@
       <filterset>
         <filter token="VERSION" value="${maven.project.version}"/>
         <filter token="DISTRIB_VERSION" value="${nuxeo.target.version}"/>
+        <filter token="HF_VERSION" value="${nuxeo.distribution.version}"/>
       </filterset>
     </copy>
     <copy file="${outdir}/nuxeo-ai-image-quality-artifacts.properties" todir="${outdir}/marketplace/install"/>

--- a/addons/nuxeo-ai-image-quality-package/src/main/resources/package.xml
+++ b/addons/nuxeo-ai-image-quality-package/src/main/resources/package.xml
@@ -6,11 +6,8 @@
   </description>
   <!-- <home-page>http://doc.nuxeo.com/</home-page> -->
   <vendor>Nuxeo</vendor>
-  <installer restart="true"/>
-  <uninstaller restart="true"/>
-  <!-- <hotreload-support>false</hotreload-support> -->
-  <!-- <require-terms-and-conditions-acceptance>false</require-terms-and-conditions-acceptance> -->
-  <!-- Nuxeo Validation: none | inprocess | primary_validation | nuxeo_certified -->
+  <installer restart="true" />
+  <uninstaller restart="true" />
   <nuxeo-validation>nuxeo_certified</nuxeo-validation>
   <!-- Production State: production_ready | testing | proto -->
   <production-state>production_ready</production-state>
@@ -19,22 +16,10 @@
     <platform>server-@DISTRIB_VERSION@</platform>
     <platform>server-@DISTRIB_VERSION@-HF*</platform>
   </platforms>
-  <!-- Dependencies on other packages -->
   <dependencies>
     <package>nuxeo-ai-core:@VERSION@:@VERSION@</package>
-    <!-- If you require JSF UI package:  -->
-    <!-- <package>nuxeo-jsf-ui</package> -->
-    <!-- If you require WEB UI package:  -->
-    <!-- <package>nuxeo-web-ui</package> -->
+    <package>nuxeo-@HF_VERSION@</package>
   </dependencies>
-  <!-- Conflicts with other packages -->
-  <!-- <conflicts> -->
-  <!-- <package>a-conflicting-package:1.0.0:1.0.0</package> -->
-  <!-- </conflicts> -->
-  <!-- Provides features of other packages -->
-  <!-- <provides> -->
-  <!-- <package>an-embedded-package:1.0.0:1.0.0</package> -->
-  <!-- </provides> -->
   <license>Apache License, Version 2.0</license>
   <license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
   <!-- Visibility: PRIVATE | MARKETPLACE | DEV | PUBLIC -->

--- a/nuxeo-ai-core-package/src/main/assemble/assembly.xml
+++ b/nuxeo-ai-core-package/src/main/assemble/assembly.xml
@@ -22,6 +22,7 @@
       <filterset>
         <filter token="VERSION" value="${maven.project.version}"/>
         <filter token="DISTRIB_VERSION" value="${nuxeo.target.version}"/>
+        <filter token="HF_VERSION" value="${nuxeo.distribution.version}"/>
       </filterset>
     </copy>
     <copy file="${outdir}/nuxeo-ai-core-artifacts.properties" todir="${outdir}/marketplace/install"/>

--- a/nuxeo-ai-core-package/src/main/resources/package.xml
+++ b/nuxeo-ai-core-package/src/main/resources/package.xml
@@ -8,9 +8,6 @@
   <vendor>Nuxeo</vendor>
   <installer restart="true" />
   <uninstaller restart="true" />
-  <!-- <hotreload-support>false</hotreload-support> -->
-  <!-- <require-terms-and-conditions-acceptance>false</require-terms-and-conditions-acceptance> -->
-  <!-- Nuxeo Validation: none | inprocess | primary_validation | nuxeo_certified -->
   <nuxeo-validation>nuxeo_certified</nuxeo-validation>
   <!-- Production State: production_ready | testing | proto -->
   <production-state>production_ready</production-state>
@@ -19,22 +16,10 @@
     <platform>server-@DISTRIB_VERSION@</platform>
     <platform>server-@DISTRIB_VERSION@-HF*</platform>
   </platforms>
-  <!-- Dependencies on other packages -->
   <dependencies>
-  <!-- <package>another-package:1.0.0:1.0.0</package> -->
-  <!-- If you require JSF UI package:  -->
-  <!-- <package>nuxeo-jsf-ui</package> -->
-  <!-- If you require WEB UI package:  -->
     <package>nuxeo-web-ui</package>
+    <package>nuxeo-@HF_VERSION@</package>
   </dependencies>
-  <!-- Conflicts with other packages -->
-  <!-- <conflicts> -->
-  <!-- <package>a-conflicting-package:1.0.0:1.0.0</package> -->
-  <!-- </conflicts> -->
-  <!-- Provides features of other packages -->
-  <!-- <provides> -->
-  <!-- <package>an-embedded-package:1.0.0:1.0.0</package> -->
-  <!-- </provides> -->
   <license>Apache License, Version 2.0</license>
   <license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
   <!-- Visibility: PRIVATE | MARKETPLACE | DEV | PUBLIC -->

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <nuxeo.ai.version>2.5.1-SNAPSHOT</nuxeo.ai.version>
     <tensorflow.version>1.11.0</tensorflow.version>
     <nuxeo.target.version>10.10</nuxeo.target.version>
+    <nuxeo.latest.version>10.10-HF41</nuxeo.latest.version>
     <wiremock.version>2.18.0</wiremock.version>
     <nuxeo.cloud.client.version>3.5.0</nuxeo.cloud.client.version>
     <nuxeo-jira-ai.version>0.1.0</nuxeo-jira-ai.version>
@@ -136,7 +137,7 @@
         <groupId>org.nuxeo.elasticsearch</groupId>
         <artifactId>nuxeo-elasticsearch-core</artifactId>
         <classifier>tests</classifier>
-        <version>${nuxeo.distribution.version}</version>
+        <version>${nuxeo.platform.version}</version>
       </dependency>
       <dependency>
         <groupId>org.nuxeo.ai</groupId>


### PR DESCRIPTION
Add a dependency to the minimum required HF version. The same version is used for the build and unit tests.
Use the latest HF version for building the Docker image used for the functional tests.
Those two versions do not need to be aligned.