### PR TITLE
AICORE-612: Check for doc base versions when enriching & improve logs

### DIFF
--- a/nuxeo-ai-core/src/main/java/org/nuxeo/ai/functions/SaveEnrichmentFunction.java
+++ b/nuxeo-ai-core/src/main/java/org/nuxeo/ai/functions/SaveEnrichmentFunction.java
@@ -25,6 +25,7 @@ import org.nuxeo.ai.enrichment.EnrichmentMetadata;
 import org.nuxeo.ai.services.DocMetadataService;
 import org.nuxeo.ecm.core.api.CoreInstance;
 import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.DocumentRef;
 import org.nuxeo.ecm.core.api.validation.ConstraintViolation;
 import org.nuxeo.ecm.core.api.validation.DocumentValidationException;
 import org.nuxeo.runtime.api.Framework;
@@ -41,30 +42,53 @@ public class SaveEnrichmentFunction extends AbstractEnrichmentConsumer {
     public void accept(EnrichmentMetadata metadata) {
         TransactionHelper.runInTransaction(() -> CoreInstance.doPrivileged(metadata.context.repositoryName, session -> {
             DocMetadataService docMetadataService = Framework.getService(DocMetadataService.class);
+
+            log.debug("Saving enrichment for document {}.", metadata.context.documentRef);
             DocumentModel doc = docMetadataService.saveEnrichment(session, metadata);
-            if (doc != null) {
-                try {
-                    if (!doc.isImmutable()) {
-                        log.debug("Saving enrichment for document {}.", doc.getId());
-                        session.saveDocument(doc);
-                    } else {
-                        log.error("Attempt to write into an Immutable Document Model id: {}, AI Model name {}",
-                                doc.getId(), metadata.getModelName());
-                    }
-                } catch (DocumentValidationException e) {
-                    log.warn("Failed to save document enrichment data for {}; error {}", metadata.context.documentRef,
-                            e.getMessage());
-                    if (log.isDebugEnabled()) {
-                        // log field violations
-                        List<ConstraintViolation> violations = e.getReport().asList();
-                        for (ConstraintViolation violation : violations) {
-                            log.debug("Constraint: {}, Value: {}", violation.getConstraint().getDescription(),
-                                    violation.getInvalidValue());
-                        }
+
+            if (doc == null) {
+                log.warn("Failed to save enrichment for document {}.", metadata.context.documentRef);
+                return null;
+            }
+
+            log.debug("Checking if the document is checked out and if a base version exists for the document {}.",
+                    doc.getId());
+
+            DocumentRef baseVersionRef = session.getBaseVersion(doc.getRef());
+
+            if (baseVersionRef == null && !doc.isCheckedOut()) {
+                log.error(
+                        "Failed to save enrichment for document {}. The document is corrupt and requires a "
+                                + "manual intervention to be fixed. The document is not checked out and no base version was found.",
+                        doc.getId());
+                return null;
+            }
+
+            if (doc.isImmutable()) {
+                log.error("Attempt to write into an Immutable Document Model id: {}, AI Model name {}", doc.getId(),
+                        metadata.getModelName());
+                return null;
+            }
+
+            try {
+                log.debug("Saving enrichment for document {}.", doc.getId());
+                session.saveDocument(doc);
+                log.debug("Enrichment for document {} was successfully saved.", doc.getId());
+            } catch (DocumentValidationException e) {
+                log.warn("Failed to save document enrichment data for {}; error: {}", metadata.context.documentRef,
+                        e.getMessage());
+                if (log.isDebugEnabled()) {
+                    // log field violations
+                    List<ConstraintViolation> violations = e.getReport().asList();
+                    for (ConstraintViolation violation : violations) {
+                        log.debug("Constraint: {}, Value: {}", violation.getConstraint().getDescription(),
+                                violation.getInvalidValue());
                     }
                 }
-            } else {
-                log.debug("Failed to save enrichment for document {}.", metadata.context.documentRef);
+            } catch (Exception e) {
+                log.error("An unexpected exception occurred saving enrichment for document with id {}; error: {}",
+                        doc.getId(), e.getMessage());
+                throw e;
             }
 
             return null;

--- a/nuxeo-ai-core/src/main/java/org/nuxeo/ai/services/DocMetadataServiceImpl.java
+++ b/nuxeo-ai-core/src/main/java/org/nuxeo/ai/services/DocMetadataServiceImpl.java
@@ -43,12 +43,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import org.nuxeo.ai.AIConstants.AUTO;
 import org.nuxeo.ai.auto.AutoHistory;
 import org.nuxeo.ai.enrichment.EnrichmentMetadata;
@@ -69,7 +67,6 @@ import org.nuxeo.ecm.platform.audit.api.LogEntry;
 import org.nuxeo.ecm.platform.audit.impl.ExtendedInfoImpl;
 import org.nuxeo.runtime.api.Framework;
 import org.nuxeo.runtime.model.DefaultComponent;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 
 /**
@@ -77,12 +74,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
  */
 public class DocMetadataServiceImpl extends DefaultComponent implements DocMetadataService {
 
-    public static final String ENRICHMENT_ADDED = "ENRICHMENT_ADDED";
+    private static final Logger log = LogManager.getLogger(DocMetadataServiceImpl.class);
 
     protected static final TypeReference<List<AutoHistory>> HISTORY_TYPE = new TypeReference<List<AutoHistory>>() {
     };
 
-    private static final Logger log = LogManager.getLogger(DocMetadataServiceImpl.class);
+    public static final String ENRICHMENT_ADDED = "ENRICHMENT_ADDED";
 
     /**
      * Have one of the supplied properties been modified?
@@ -111,7 +108,7 @@ public class DocMetadataServiceImpl extends DefaultComponent implements DocMetad
         try {
             doc = session.getDocument(new IdRef(metadata.context.documentRef));
         } catch (DocumentNotFoundException e) {
-            log.info("Unable to save enrichment data for missing doc " + metadata.context.documentRef);
+            log.warn("Unable to save enrichment data for missing doc {}", metadata.context.documentRef);
             return null;
         }
 
@@ -139,7 +136,7 @@ public class DocMetadataServiceImpl extends DefaultComponent implements DocMetad
      * Updates enrichment, ensures we have one enrichment entry per model/version and input
      */
     protected Collection<Map<String, Object>> updateEnrichment(List<Map<String, Object>> original,
-                                                               Map<String, Object> item) {
+            Map<String, Object> item) {
         Map<String, Map<String, Object>> enrichmentByKey = new HashMap<>();
         original.forEach(o -> enrichmentByKey.put(uniqueKey(o), o));
         enrichmentByKey.put(uniqueKey(item), item);
@@ -164,7 +161,7 @@ public class DocMetadataServiceImpl extends DefaultComponent implements DocMetad
 
     @Override
     public DocumentModel updateAuto(DocumentModel doc, AUTO autoField, String xPath, String model,
-                                    Serializable oldValue, String comment) {
+            Serializable oldValue, String comment) {
         if (!doc.hasFacet(ENRICHMENT_FACET)) {
             doc.addFacet(ENRICHMENT_FACET);
         }
@@ -197,22 +194,18 @@ public class DocMetadataServiceImpl extends DefaultComponent implements DocMetad
     @Override
     public DocumentModel resetAuto(DocumentModel doc, AUTO autoField, String xPath, boolean resetValue) {
         List<AutoHistory> history = getAutoHistory(doc);
-        Optional<AutoHistory> previous = history.stream()
-                                                .filter(h -> xPath.equals(h.getProperty()))
-                                                .findFirst();
+        Optional<AutoHistory> previous = history.stream().filter(h -> xPath.equals(h.getProperty())).findFirst();
         boolean present = previous.isPresent();
         Set<Map<String, String>> set = getAutoPropAsSet(doc, autoField.lowerName());
         Set<Map<String, String>> toReset = set.stream()
-                                              .filter(val -> val.get("xpath")
-                                                                .equals(xPath))
+                                              .filter(val -> val.get("xpath").equals(xPath))
                                               .collect(Collectors.toSet());
         @SuppressWarnings("unchecked")
         Collection<Map<String, String>> noOldXpath = CollectionUtils.disjunction(set, toReset);
         Object previousValue = null;
         if (set.size() > noOldXpath.size()) {
             if (present) {
-                previousValue = previous.get()
-                                        .getPreviousValue();
+                previousValue = previous.get().getPreviousValue();
                 history.remove(previous.get());
                 setAutoHistory(doc, history);
             }
@@ -271,8 +264,7 @@ public class DocMetadataServiceImpl extends DefaultComponent implements DocMetad
     }
 
     protected void raiseEvent(DocumentModel doc, String eventName, Set<String> xPaths, String comment) {
-        DocumentEventContext ctx = new DocumentEventContext(doc.getCoreSession(), doc.getCoreSession()
-                                                                                     .getPrincipal(),
+        DocumentEventContext ctx = new DocumentEventContext(doc.getCoreSession(), doc.getCoreSession().getPrincipal(),
                 doc);
         ctx.setProperty(CoreEventConstants.REPOSITORY_NAME, doc.getRepositoryName());
         ctx.setProperty(CoreEventConstants.SESSION_ID, doc.getSessionId());
@@ -287,8 +279,7 @@ public class DocMetadataServiceImpl extends DefaultComponent implements DocMetad
         } else {
             ctx.setProperty(COMMENT_PROPERTY_KEY, comment);
         }
-        Framework.getService(EventService.class)
-                 .fireEvent(ctx.newEvent(eventName));
+        Framework.getService(EventService.class).fireEvent(ctx.newEvent(eventName));
     }
 
     @Override


### PR DESCRIPTION
https://jira.nuxeo.com/browse/AICORE-612

We have encountered a NullPointerException within SaveEnrichmentFunction. This was a result of corrupted documents where the documents did not have base versions. This change makes an improvement to the class. We now check if the base version is null and if it is null and the document is not checked out, we exit, returning null. Additionally, this change improves logging within the class, adding an error log for unexpected exceptions along with a couple other logs. The class also had a couple small refactors as well.

```
java.lang.NullPointerException: null at org.nuxeo.ecm.core.versioning.StandardVersioningService.doCheckOut(StandardVersioningService.java:374) ~[nuxeo-core-10.10-HF71.jar:?] at org.nuxeo.ecm.core.versioning.StandardVersioningService.doPreSave(StandardVersioningService.java:325) ~[nuxeo-core-10.10-HF71.jar:?] at org.nuxeo.ecm.core.versioning.VersioningComponent.doPreSave(VersioningComponent.java:423) ~[nuxeo-core-10.10-HF71.jar:?] at org.nuxeo.ecm.core.api.AbstractSession.saveDocument(AbstractSession.java:1613) ~[nuxeo-core-10.10-HF71.jar:?] at org.nuxeo.ai.functions.SaveEnrichmentFunction.lambda$null$0(SaveEnrichmentFunction.java:49) ~[nuxeo-ai-core-2.7.19.jar:?] at org.nuxeo.ecm.core.api.CoreInstance$1.run(CoreInstance.java:186) ~[nuxeo-core-api-10.10-HF71.jar:?]
```
