### PR TITLE
AICORE-614: Deploy packages to Nexus and the Marketplace

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -105,9 +105,44 @@ jobs:
     - name: Publish Test Report
       if: ${{ always() }}
       uses: scacap/action-surefire-report@v1
+    - name: Get project version
+      run: echo "VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec | xargs echo -n)" >> $GITHUB_ENV
+    - run: ls -alR | grep ".*package.*.zip"
+    - run: ls -alR | grep ".*nuxeo-ai-core-.*.zip"
+    - name: Upload packages build artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: nuxeo-ai-github-packages-build
+        path: |
+          ./**/target/**/*package*.zip
+          ./nuxeo-ai-core-package/target/nuxeo-ai-core-${{ env.VERSION }}.zip
     - name: Publish package
       if: ${{ inputs.should-push }}
       run: mvn --batch-mode deploy -nsu -DskipTests
+    - name: Publish nuxeo-ai-core package to Production Connect Marketplace
+      if: ${{ inputs.should-push }}
+      env:
+        PACKAGE: nuxeo-ai-core-package/target/nuxeo-ai-core-${{ env.VERSION }}.zip
+        CONNECT_URL: https://connect.nuxeo.com/nuxeo
+      run: curl -i -u "${{ secrets.connect-auth-user }}:${{ secrets.connect-auth-token }}" -F package=@$PACKAGE "$CONNECT_URL/site/marketplace/upload?batch=true"
+    - name: Publish nuxeo-ai-aws-package package to Production Connect Marketplace
+      if: ${{ inputs.should-push }}
+      env:
+        PACKAGE: addons/nuxeo-ai-aws-package/target/nuxeo-ai-aws-package-${{ env.VERSION }}.zip
+        CONNECT_URL: https://connect.nuxeo.com/nuxeo
+      run: curl -i -u "${{ secrets.connect-auth-user }}:${{ secrets.connect-auth-token }}" -F package=@$PACKAGE "$CONNECT_URL/site/marketplace/upload?batch=true"
+    - name: Publish nuxeo-ai-gcp-package package to Production Connect Marketplace
+      if: ${{ inputs.should-push }}
+      env:
+        PACKAGE: addons/nuxeo-ai-gcp-package/target/nuxeo-ai-gcp-package-${{ env.VERSION }}.zip
+        CONNECT_URL: https://connect.nuxeo.com/nuxeo
+      run: curl -i -u "${{ secrets.connect-auth-user }}:${{ secrets.connect-auth-token }}" -F package=@$PACKAGE "$CONNECT_URL/site/marketplace/upload?batch=true"
+    - name: Publish nuxeo-ai-image-quality-package package to Production Connect Marketplace
+      if: ${{ inputs.should-push }}
+      env:
+        PACKAGE: addons/nuxeo-ai-aws-package/target/nuxeo-ai-image-quality-package-${{ env.VERSION }}.zip
+        CONNECT_URL: https://connect.nuxeo.com/nuxeo
+      run: curl -i -u "${{ secrets.connect-auth-user }}:${{ secrets.connect-auth-token }}" -F package=@$PACKAGE "$CONNECT_URL/site/marketplace/upload?batch=true"
   build-master:
     name: 'Build Master LTS'
     runs-on: ubuntu-latest
@@ -181,6 +216,41 @@ jobs:
     - name: Publish Test Report
       if: ${{ always() }}
       uses: scacap/action-surefire-report@v1
+    - name: Get project version
+      run: echo "VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec | xargs echo -n)" >> $GITHUB_ENV
+    - run: ls -alR | grep ".*package.*.zip"
+    - run: ls -alR | grep ".*nuxeo-ai-core-.*.zip"
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: nuxeo-ai-github-build
+        path: |
+          ./**/target/**/*package*.zip
+          ./nuxeo-ai-core-package/target/nuxeo-ai-core-*.zip
     - name: Publish package
       if: ${{ inputs.should-push }}
       run: mvn --batch-mode deploy -nsu -DskipTests
+    - name: Publish nuxeo-ai-core package to Production Connect Marketplace
+      if: ${{ inputs.should-push }}
+      env:
+        PACKAGE: nuxeo-ai-core-package/target/nuxeo-ai-core-${{ env.VERSION }}.zip
+        CONNECT_URL: https://connect.nuxeo.com/nuxeo
+      run: curl -i -u "${{ secrets.connect-auth-user }}:${{ secrets.connect-auth-token }}" -F package=@$PACKAGE "$CONNECT_URL/site/marketplace/upload?batch=true"
+    - name: Publish nuxeo-ai-aws-package package to Production Connect Marketplace
+      if: ${{ inputs.should-push }}
+      env:
+        PACKAGE: addons/nuxeo-ai-aws-package/target/nuxeo-ai-aws-package-${{ env.VERSION }}.zip
+        CONNECT_URL: https://connect.nuxeo.com/nuxeo
+      run: curl -i -u "${{ secrets.connect-auth-user }}:${{ secrets.connect-auth-token }}" -F package=@$PACKAGE "$CONNECT_URL/site/marketplace/upload?batch=true"
+    - name: Publish nuxeo-ai-gcp-package package to Production Connect Marketplace
+      if: ${{ inputs.should-push }}
+      env:
+        PACKAGE: addons/nuxeo-ai-gcp-package/target/nuxeo-ai-gcp-package-${{ env.VERSION }}.zip
+        CONNECT_URL: https://connect.nuxeo.com/nuxeo
+      run: curl -i -u "${{ secrets.connect-auth-user }}:${{ secrets.connect-auth-token }}" -F package=@$PACKAGE "$CONNECT_URL/site/marketplace/upload?batch=true"
+    - name: Publish nuxeo-ai-image-quality-package package to Production Connect Marketplace
+      if: ${{ inputs.should-push }}
+      env:
+        PACKAGE: addons/nuxeo-ai-aws-package/target/nuxeo-ai-image-quality-package-${{ env.VERSION }}.zip
+        CONNECT_URL: https://connect.nuxeo.com/nuxeo
+      run: curl -i -u "${{ secrets.connect-auth-user }}:${{ secrets.connect-auth-token }}" -F package=@$PACKAGE "$CONNECT_URL/site/marketplace/upload?batch=true"

--- a/addons/nuxeo-ai-aws-package/src/main/assemble/assembly.xml
+++ b/addons/nuxeo-ai-aws-package/src/main/assemble/assembly.xml
@@ -142,9 +142,7 @@
     </nx:studioExtraction>
 
     <zip destfile="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip" basedir="${outdir}/marketplace"/>
-    <zip destfile="${outdir}/dummy-package.zip" whenempty="create" includes="" excludes="**" basedir="${outdir}"
-         comment="This package is only available in the Marketplace"/>
-    <artifact:attach file="${outdir}/dummy-package.zip" type="zip"/>
+    <artifact:attach file="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip" type="zip"/>
   </target>
 
 </project>

--- a/addons/nuxeo-ai-gcp-package/src/main/assemble/assembly.xml
+++ b/addons/nuxeo-ai-gcp-package/src/main/assemble/assembly.xml
@@ -142,9 +142,7 @@
     </nx:studioExtraction>
 
     <zip destfile="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip" basedir="${outdir}/marketplace"/>
-    <zip destfile="${outdir}/dummy-package.zip" whenempty="create" includes="" excludes="**" basedir="${outdir}"
-         comment="This package is only available in the Marketplace"/>
-    <artifact:attach file="${outdir}/dummy-package.zip" type="zip"/>
+    <artifact:attach file="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip" type="zip"/>
   </target>
 
 </project>

--- a/addons/nuxeo-ai-image-quality-package/src/main/assemble/assembly.xml
+++ b/addons/nuxeo-ai-image-quality-package/src/main/assemble/assembly.xml
@@ -144,9 +144,7 @@
     </nx:studioExtraction>
 
     <zip destfile="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip" basedir="${outdir}/marketplace"/>
-    <zip destfile="${outdir}/dummy-package.zip" whenempty="create" includes="" excludes="**" basedir="${outdir}"
-         comment="This package is only available in the Marketplace"/>
-    <artifact:attach file="${outdir}/dummy-package.zip" type="zip"/>
+    <artifact:attach file="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip" type="zip"/>
   </target>
 
 </project>

--- a/nuxeo-ai-core-package/src/main/assemble/assembly.xml
+++ b/nuxeo-ai-core-package/src/main/assemble/assembly.xml
@@ -144,9 +144,7 @@
     </nx:studioExtraction>
 
     <zip destfile="${outdir}/nuxeo-ai-core-${maven.project.version}.zip" basedir="${outdir}/marketplace"/>
-    <zip destfile="${outdir}/dummy-package.zip" whenempty="create" includes="" excludes="**" basedir="${outdir}"
-         comment="This package is only available in the Marketplace"/>
-    <artifact:attach file="${outdir}/dummy-package.zip" type="zip"/>
+    <artifact:attach file="${outdir}/nuxeo-ai-core-${maven.project.version}.zip" type="zip"/>
   </target>
 
 </project>


### PR DESCRIPTION
This change adds automatic deployments of packages to Nuxeo's Sonatype Nexus Repository Manager packages repository and it adds automatic deployments of the packages to the Production Connect Marketplace as well.

A while back, we stopped pushing the packages as maven artifacts, instead attaching empty dummy packages, due to duplicate JAR deployments. This was while we were still using Jenkins for our pipeline. For reference, see: https://github.com/nuxeo/nuxeo-ai/pull/383

We no longer use Jenkins, and we need to deploy our packages for our subscribers, so we are reverting that dummy package change and enabling publishing of our release packages to Nexus and more importantly, the Marketplace.

This uses similar logic as the `nuxeo-web-ui`. For reference, see

https://github.com/nuxeo/nuxeo-web-ui/blob/6e3fceb90896a414a8187556c91ad9d71b611f7e/.github/workflows/promote.yaml#LL104C1-L110C1

In addition, we also added a couple steps in the workflow, such as a step which creates an GitHub Actions artifact of the packages, for testing and verification purposes.