### PR TITLE
Use {revision} to consolidate version

### DIFF
--- a/addons/nuxeo-ai-aws-core/pom.xml
+++ b/addons/nuxeo-ai-aws-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>nuxeo-ai-aws-core</artifactId>
   <name>Nuxeo AI AWS Core</name>

--- a/addons/nuxeo-ai-aws-package/pom.xml
+++ b/addons/nuxeo-ai-aws-package/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>nuxeo-ai-aws-package</artifactId>
   <packaging>zip</packaging>

--- a/addons/nuxeo-ai-gcp-core/pom.xml
+++ b/addons/nuxeo-ai-gcp-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>nuxeo-ai-gcp-core</artifactId>
   <name>Nuxeo AI GCP Core</name>

--- a/addons/nuxeo-ai-gcp-package/pom.xml
+++ b/addons/nuxeo-ai-gcp-package/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>nuxeo-ai-gcp-package</artifactId>
   <packaging>zip</packaging>

--- a/addons/nuxeo-ai-image-quality-core/pom.xml
+++ b/addons/nuxeo-ai-image-quality-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>nuxeo-ai-image-quality-core</artifactId>
   <name>Nuxeo AI image quality core</name>

--- a/addons/nuxeo-ai-image-quality-package/pom.xml
+++ b/addons/nuxeo-ai-image-quality-package/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>nuxeo-ai-addons</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nuxeo-ai-image-quality-package</artifactId>

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>nuxeo-ai-addons</artifactId>
   <name>Nuxeo AI Addons parent POM</name>

--- a/nuxeo-ai-config/pom.xml
+++ b/nuxeo-ai-config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>nuxeo-ai-config</artifactId>
   <name>Nuxeo AI Config Module</name>

--- a/nuxeo-ai-core-package/pom.xml
+++ b/nuxeo-ai-core-package/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nuxeo-ai-core-package</artifactId>

--- a/nuxeo-ai-core/pom.xml
+++ b/nuxeo-ai-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>nuxeo-ai-core</artifactId>
   <name>Ai core</name>

--- a/nuxeo-ai-internal/pom.xml
+++ b/nuxeo-ai-internal/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>nuxeo-ai-internal</artifactId>
   <name>AI Core Internal</name>

--- a/nuxeo-ai-model/pom.xml
+++ b/nuxeo-ai-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>nuxeo-ai-model</artifactId>
   <name>Ai custom models</name>

--- a/nuxeo-ai-pipes/pom.xml
+++ b/nuxeo-ai-pipes/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nuxeo-ai-pipes</artifactId>

--- a/nuxeo-ai-similar-content/pom.xml
+++ b/nuxeo-ai-similar-content/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>ai-core-parent</artifactId>
     <groupId>org.nuxeo.ai</groupId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/nuxeo-ai-web-ui/pom.xml
+++ b/nuxeo-ai-web-ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.nuxeo.ai</groupId>
     <artifactId>ai-core-parent</artifactId>
-    <version>3.5.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,13 +9,14 @@
 
   <groupId>org.nuxeo.ai</groupId>
   <artifactId>ai-core-parent</artifactId>
-  <version>3.5.10-SNAPSHOT</version>
+  <version>${revision}</version>
   <name>Ai core parent</name>
   <description>Nuxeo AI functionality</description>
   <packaging>pom</packaging>
 
   <properties>
-    <nuxeo.ai.version>3.5.10-SNAPSHOT</nuxeo.ai.version>
+    <revision>3.5.10-SNAPSHOT</revision>
+    <nuxeo.ai.version>${revision}</nuxeo.ai.version>
     <dropwizard.version>4.1.17</dropwizard.version>
     <tensorflow.version>1.11.0</tensorflow.version>
     <nuxeo.target.version>2021.*</nuxeo.target.version>
@@ -302,6 +303,34 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+        </configuration>
+        <executions>
+          <!-- enable flattening -->
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <!-- ensure proper cleanup -->
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.4.1</version>
+          <version>1.4.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,11 @@
           <artifactId>maven-help-plugin</artifactId>
           <version>3.2.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.4.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
By using the revision property this allows us to centralize where the version is specified to just the parent pom. All child poms will use the ${revision} property, which resolves to the value set in the root.