### PR TITLE
NXCON-57: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,6 +36,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  checks: write
 
 jobs:
   build:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,6 +33,10 @@ on:
       google-creds:
         required: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     name: "Build"


### PR DESCRIPTION
This pull request adds permissions configuration to the GitHub Actions workflow to specify access levels for contents and pull requests. This helps ensure that the workflow only has the necessary permissions for its tasks.

Permissions configuration:

* [`.github/workflows/build_and_test.yml`](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2R36-R39): Added a `permissions` section to grant `read` access to `contents` and `write` access to `pull-requests` for the workflow.