### PR TITLE
NXCON-58: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline_pr.yaml
+++ b/.github/workflows/pipeline_pr.yaml
@@ -1,4 +1,8 @@
 name: CI for PR
+
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [master, master-10.10, release-*, '2023']

--- a/.github/workflows/pipeline_release.yml
+++ b/.github/workflows/pipeline_release.yml
@@ -1,5 +1,8 @@
 name: Release Publish
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Added a permissions block to the workflow file to improve security by following the principle of least privilege.
This pull request updates GitHub Actions workflow configuration files to explicitly set permissions for workflow runs, improving security and compliance with best practices.

Workflow permissions updates:

* [`.github/workflows/pipeline_pr.yaml`](diffhunk://#diff-d43845cad380aad9793b8a008817dd8e1b7c253284535788bc9459053b3e2741R2-R5): Added `permissions` block to restrict access to read-only for repository contents during pull request workflows.
* [`.github/workflows/pipeline_release.yml`](diffhunk://#diff-4cd861890a330dd4127ed5aed1c5fed5fb94dc4b77b01d6f4488eaf023032414R3-R5): Added `permissions` block to allow write access to repository contents during release publishing workflows.

contents: read for PR workflows because they only need to read code for building and testing, not write or modify anything.
contents: write for release workflows because publishing a release requires creating tags, uploading assets, or modifying repository contents.
This targeted approach ensures workflows have only the access they need for their specific tasks.