### PR TITLE
NXCON-47: Update notifications channel from Slack to Teams for nuxeo-ai

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,6 +32,8 @@ on:
         required: true
       google-creds:
         required: true
+      TEAMS_WEBHOOK_URL:
+        required: true
 
 permissions:
   contents: read
@@ -154,15 +156,15 @@ jobs:
   
 
   notify-on-error:
-    runs-on: ubuntu-latest
     needs: [build]
     if: ${{ failure() && inputs.should-push }}
-    steps:
-      - name: Slack Notification
-        id: slack
-        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
-        with:
-          channel-id: "C9W4P9RKM"
-          slack-message: "Nuxeo AI Core ${{ github.workflow }} workflow failed!\n${{ github.event.head_commit.url }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATION_BOT_TOKEN }}
+    uses: ./.github/workflows/notify_teams.yml
+    with:
+      message_type: "❌ Nuxeo AI Core ${{ github.workflow }} workflow failed!"
+      workflow_name: ${{ github.workflow }}
+      status: "failure"
+      details: "Build or publish step failed."
+      run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      actor: "${{ github.actor }}"
+    secrets:
+      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}

--- a/.github/workflows/notify_teams.yml
+++ b/.github/workflows/notify_teams.yml
@@ -1,0 +1,77 @@
+name: Notify Teams
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      message_type:
+        required: true
+        type: string
+      workflow_name:
+        required: true
+        type: string
+      status:
+        required: true
+        type: string
+      details:
+        required: false
+        type: string
+      run_url:
+        required: true
+        type: string
+      actor:
+        required: false
+        type: string
+    secrets:
+      TEAMS_WEBHOOK_URL:
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Teams Notification
+        run: |
+          curl -X POST "${{ secrets.TEAMS_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "attachments": [
+                {
+                  "contentType": "application/vnd.microsoft.card.adaptive",
+                  "content": {
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type": "AdaptiveCard",
+                    "version": "1.4",
+                    "body": [
+                      {
+                        "type": "TextBlock",
+                        "text": "${{ inputs.message_type }}",
+                        "weight": "Bolder",
+                        "size": "Medium",
+                        "color": "${{ inputs.status == 'failure' ? 'Attention' : 'Good' }}"
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "Workflow: ${{ inputs.workflow_name }}",
+                        "wrap": true
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "Actor: ${{ inputs.actor || 'N/A' }}",
+                        "wrap": true
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "Details: ${{ inputs.details || 'N/A' }}",
+                        "wrap": true
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "🔗 [View Workflow Run](${{ inputs.run_url }})",
+                        "wrap": true
+                      }
+                    ]
+                  }
+                }
+              ]
+            }'

--- a/.github/workflows/notify_teams.yml
+++ b/.github/workflows/notify_teams.yml
@@ -30,6 +30,15 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      - name: Set color based on status
+        id: set-color
+        run: |
+          if [ "${{ inputs.status }}" = "failure" ]; then
+            echo "color=Attention" >> $GITHUB_OUTPUT
+          else
+            echo "color=Good" >> $GITHUB_OUTPUT
+          fi
+
       - name: Send Teams Notification
         run: |
           curl -X POST "${{ secrets.TEAMS_WEBHOOK_URL }}" \
@@ -48,7 +57,7 @@ jobs:
                         "text": "${{ inputs.message_type }}",
                         "weight": "Bolder",
                         "size": "Medium",
-                        "color": "${{ inputs.status == 'failure' ? 'Attention' : 'Good' }}"
+                        "color": "${{ steps.set-color.outputs.color }}"
                       },
                       {
                         "type": "TextBlock",

--- a/.github/workflows/pipeline_pr.yaml
+++ b/.github/workflows/pipeline_pr.yaml
@@ -5,7 +5,6 @@ permissions:
   checks: write
   pull-requests: write
 
-
 on:
   pull_request:
     branches: [master, master-10.10, release-*, '2023']
@@ -27,3 +26,4 @@ jobs:
       connect-auth-user: ${{secrets.CONNECT_AUTH_USER}}
       connect-auth-token: ${{secrets.CONNECT_AUTH_TOKEN}}
       google-creds: ${{secrets.GOOGLE_CREDENTIALS}}
+      TEAMS_WEBHOOK_URL: ${{secrets.TEAMS_WEBHOOK_URL}}

--- a/.github/workflows/pipeline_release.yml
+++ b/.github/workflows/pipeline_release.yml
@@ -131,7 +131,7 @@ jobs:
 
   notify-on-success:
     needs: release-publish
-    if: ${{ !failure() }}
+    if: ${{ success() }}
     uses: ./.github/workflows/notify_teams.yml
     with:
       message_type: "✅ Nuxeo AI Core ${{ github.workflow }} workflow succeeded!"

--- a/.github/workflows/pipeline_release.yml
+++ b/.github/workflows/pipeline_release.yml
@@ -2,6 +2,8 @@ name: Release Publish
 
 permissions:
   contents: write
+  packages: write
+  actions: read
 
 on:
   workflow_dispatch:
@@ -76,7 +78,6 @@ jobs:
           mvn -ntp install -DskipInstall
           git push origin v${releasedVersion}
           git push origin release-v${releasedVersion}
-
       - name: Archive packages
         uses: actions/upload-artifact@v2
         with:
@@ -115,15 +116,29 @@ jobs:
           git push origin ${{ github.base_ref }}
 
   notify-on-error:
-    runs-on: ubuntu-latest
     needs: release-publish
     if: ${{ failure() }}
-    steps:
-      - name: Slack Notification
-        id: slack
-        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
-        with:
-          channel-id: "C9W4P9RKM"
-          slack-message: "Nuxeo AI Core ${{ github.workflow }} workflow failed!\n${{ github.event.head_commit.url }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATION_BOT_TOKEN }}
+    uses: ./.github/workflows/notify_teams.yml
+    with:
+      message_type: "❌ Nuxeo AI Core ${{ github.workflow }} workflow failed!"
+      workflow_name: ${{ github.workflow }}
+      status: "failure"
+      details: "Release or publish step failed."
+      run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      actor: "${{ github.actor }}"
+    secrets:
+      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+
+  notify-on-success:
+    needs: release-publish
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/notify_teams.yml
+    with:
+      message_type: "✅ Nuxeo AI Core ${{ github.workflow }} workflow succeeded!"
+      workflow_name: ${{ github.workflow }}
+      status: "success"
+      details: "Release and publish steps completed successfully."
+      run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      actor: "${{ github.actor }}"
+    secrets:
+      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}


### PR DESCRIPTION
This pull request updates our CI notification system to use Microsoft Teams instead of Slack for workflow failure alerts. It introduces a new reusable workflow for sending Teams notifications and replaces the previous Slack notification steps in our build and release pipelines.

Notification system migration:

* Added a new workflow file, `notify_teams.yml`, which sends formatted failure notifications to Microsoft Teams using a webhook and Adaptive Cards. This workflow accepts inputs such as message type, workflow name, status, details, run URL, and actor.
* Updated the failure notification steps in both `build_and_test.yml` and `pipeline_release.yml` to use the new `notify_teams.yml` workflow, replacing the previous Slack-based notifications. These steps now send detailed failure messages to Teams, including workflow context and links. [[1]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L161-R169) [[2]](diffhunk://#diff-4cd861890a330dd4127ed5aed1c5fed5fb94dc4b77b01d6f4488eaf023032414L119-R127)


In short:
Updated notification channel from Slack to Teams for Nuxeo AI workflows
Replaced Slack notifications with Microsoft Teams notifications in CI/CD workflows.
Added adaptive card formatting for Teams messages.
Ensured error notifications include workflow name, actor, details, and direct run link.
Improved maintainability by centralizing notification logic in notify_teams.yml.