### PR TITLE
Task nxcon 47 testing workflow failure notification

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -158,11 +158,12 @@ jobs:
     needs: [build]
     if: ${{ failure() && inputs.should-push }}
     steps:
-      - name: Slack Notification
-        id: slack
-        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+      - name: Notify Teams on Failure
+        uses: ./.github/workflows/notify_teams.yml
         with:
-          channel-id: "C9W4P9RKM"
-          slack-message: "Nuxeo AI Core ${{ github.workflow }} workflow failed!\n${{ github.event.head_commit.url }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATION_BOT_TOKEN }}
+          message_type: "❌ Nuxeo AI Core ${{ github.workflow }} workflow failed!"
+          workflow_name: ${{ github.workflow }}
+          status: "failure"
+          details: "Build or publish step failed."
+          run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          actor: "${{ github.actor }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -117,8 +117,6 @@ jobs:
         run: find .m2/repository/.locks -type f -delete || true
       - name: Build with Maven
         run: mvn install -fae -B -DskipTests
-      - name: Force Failure for Notification Test
-        run: exit 1
       - name: Run Tests with Maven
         run: mvn install --fail-never -nsu -B -Dnuxeo.test.elasticsearch.addressList=http://localhost:9200
       - name: Publish Test Report
@@ -164,5 +162,17 @@ jobs:
       workflow_name: ${{ github.workflow }}
       status: "failure"
       details: "Build or publish step failed."
+      run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      actor: "${{ github.actor }}"
+
+  notify-on-success:
+    needs: [build]
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/notify_teams.yml
+    with:
+      message_type: "✅ Nuxeo AI Core ${{ github.workflow }} workflow succeeded!"
+      workflow_name: ${{ github.workflow }}
+      status: "success"
+      details: "Build and tests completed successfully."
       run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       actor: "${{ github.actor }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -156,16 +156,13 @@ jobs:
   
 
   notify-on-error:
-    runs-on: ubuntu-latest
     needs: [build]
     if: ${{ failure() }}
-    steps:
-      - name: Notify Teams on Failure
-        uses: ./.github/workflows/notify_teams.yml
-        with:
-          message_type: "❌ Nuxeo AI Core ${{ github.workflow }} workflow failed!"
-          workflow_name: ${{ github.workflow }}
-          status: "failure"
-          details: "Build or publish step failed."
-          run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          actor: "${{ github.actor }}"
+    uses: ./.github/workflows/notify_teams.yml
+    with:
+      message_type: "❌ Nuxeo AI Core ${{ github.workflow }} workflow failed!"
+      workflow_name: ${{ github.workflow }}
+      status: "failure"
+      details: "Build or publish step failed."
+      run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      actor: "${{ github.actor }}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -157,27 +157,13 @@ jobs:
 
   notify-on-error:
     needs: [build]
-    if: ${{ failure() }}
+    if: ${{ failure() && inputs.should-push }}
     uses: ./.github/workflows/notify_teams.yml
     with:
       message_type: "❌ Nuxeo AI Core ${{ github.workflow }} workflow failed!"
       workflow_name: ${{ github.workflow }}
       status: "failure"
       details: "Build or publish step failed."
-      run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-      actor: "${{ github.actor }}"
-    secrets:
-      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
-
-  notify-on-success:
-    needs: [build]
-    if: ${{ !failure() }}
-    uses: ./.github/workflows/notify_teams.yml
-    with:
-      message_type: "✅ Nuxeo AI Core ${{ github.workflow }} workflow succeeded!"
-      workflow_name: ${{ github.workflow }}
-      status: "success"
-      details: "Build and tests completed successfully."
       run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       actor: "${{ github.actor }}"
     secrets:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -117,6 +117,8 @@ jobs:
         run: find .m2/repository/.locks -type f -delete || true
       - name: Build with Maven
         run: mvn install -fae -B -DskipTests
+      - name: Force Failure for Notification Test
+        run: exit 1
       - name: Run Tests with Maven
         run: mvn install --fail-never -nsu -B -Dnuxeo.test.elasticsearch.addressList=http://localhost:9200
       - name: Publish Test Report

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,6 +32,8 @@ on:
         required: true
       google-creds:
         required: true
+      TEAMS_WEBHOOK_URL:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -166,6 +166,8 @@ jobs:
       details: "Build or publish step failed."
       run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       actor: "${{ github.actor }}"
+    secrets:
+      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
 
   notify-on-success:
     needs: [build]
@@ -178,3 +180,5 @@ jobs:
       details: "Build and tests completed successfully."
       run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       actor: "${{ github.actor }}"
+    secrets:
+      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -158,7 +158,7 @@ jobs:
   notify-on-error:
     runs-on: ubuntu-latest
     needs: [build]
-    if: ${{ failure() && inputs.should-push }}
+    if: ${{ failure() }}
     steps:
       - name: Notify Teams on Failure
         uses: ./.github/workflows/notify_teams.yml

--- a/.github/workflows/notify_teams.yml
+++ b/.github/workflows/notify_teams.yml
@@ -1,0 +1,73 @@
+name: Notify Teams
+
+on:
+  workflow_call:
+    inputs:
+      message_type:
+        required: true
+        type: string
+      workflow_name:
+        required: true
+        type: string
+      status:
+        required: true
+        type: string
+      details:
+        required: false
+        type: string
+      run_url:
+        required: true
+        type: string
+      actor:
+        required: false
+        type: string
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Teams Notification
+        run: |
+          curl -X POST "${{ secrets.TEAMS_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "attachments": [
+                {
+                  "contentType": "application/vnd.microsoft.card.adaptive",
+                  "content": {
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type": "AdaptiveCard",
+                    "version": "1.4",
+                    "body": [
+                      {
+                        "type": "TextBlock",
+                        "text": "${{ inputs.message_type }}",
+                        "weight": "Bolder",
+                        "size": "Medium",
+                        "color": "${{ inputs.status == 'failure' && 'Attention' || 'Good' }}"
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "Workflow: ${{ inputs.workflow_name }}",
+                        "wrap": true
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "Actor: ${{ inputs.actor }}",
+                        "wrap": true
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "Details: ${{ inputs.details }}",
+                        "wrap": true
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "🔗 [View Workflow Run](${{ inputs.run_url }})",
+                        "wrap": true
+                      }
+                    ]
+                  }
+                }
+              ]
+            }'

--- a/.github/workflows/notify_teams.yml
+++ b/.github/workflows/notify_teams.yml
@@ -1,4 +1,5 @@
 name: Notify Teams
+permissions: {}
 
 on:
   workflow_call:

--- a/.github/workflows/notify_teams.yml
+++ b/.github/workflows/notify_teams.yml
@@ -30,14 +30,6 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Check Teams Webhook URL
-        run: |
-          if [ -z "${{ secrets.TEAMS_WEBHOOK_URL }}" ]; then
-            echo "TEAMS_WEBHOOK_URL is not set!"
-            exit 1
-          else
-            echo "TEAMS_WEBHOOK_URL is set."
-          fi
       - name: Send Teams Notification
         run: |
           curl -X POST "${{ secrets.TEAMS_WEBHOOK_URL }}" \

--- a/.github/workflows/notify_teams.yml
+++ b/.github/workflows/notify_teams.yml
@@ -22,11 +22,22 @@ on:
       actor:
         required: false
         type: string
+    secrets:
+      TEAMS_WEBHOOK_URL:
+        required: true
 
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      - name: Check Teams Webhook URL
+        run: |
+          if [ -z "${{ secrets.TEAMS_WEBHOOK_URL }}" ]; then
+            echo "TEAMS_WEBHOOK_URL is not set!"
+            exit 1
+          else
+            echo "TEAMS_WEBHOOK_URL is set."
+          fi
       - name: Send Teams Notification
         run: |
           curl -X POST "${{ secrets.TEAMS_WEBHOOK_URL }}" \

--- a/.github/workflows/pipeline_pr.yaml
+++ b/.github/workflows/pipeline_pr.yaml
@@ -20,3 +20,4 @@ jobs:
       connect-auth-user: ${{secrets.CONNECT_AUTH_USER}}
       connect-auth-token: ${{secrets.CONNECT_AUTH_TOKEN}}
       google-creds: ${{secrets.GOOGLE_CREDENTIALS}}
+      TEAMS_WEBHOOK_URL: ${{secrets.TEAMS_WEBHOOK_URL}}

--- a/.github/workflows/pipeline_pr.yaml
+++ b/.github/workflows/pipeline_pr.yaml
@@ -1,4 +1,10 @@
 name: CI for PR
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
 on:
   pull_request:
     branches: [master, master-10.10, release-*, '2023']

--- a/.github/workflows/pipeline_release.yml
+++ b/.github/workflows/pipeline_release.yml
@@ -114,16 +114,13 @@ jobs:
           git push origin ${{ github.base_ref }}
 
   notify-on-error:
-    runs-on: ubuntu-latest
     needs: release-publish
     if: ${{ failure() }}
-    steps:
-      - name: Notify Teams on Failure
-        uses: ./.github/workflows/notify_teams.yml
-        with:
-          message_type: "❌ Nuxeo AI Core ${{ github.workflow }} workflow failed!"
-          workflow_name: ${{ github.workflow }}
-          status: "failure"
-          details: "Release or publish step failed."
-          run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          actor: "${{ github.actor }}"
+    uses: ./.github/workflows/notify_teams.yml
+    with:
+      message_type: "❌ Nuxeo AI Core ${{ github.workflow }} workflow failed!"
+      workflow_name: ${{ github.workflow }}
+      status: "failure"
+      details: "Release or publish step failed."
+      run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      actor: "${{ github.actor }}"

--- a/.github/workflows/pipeline_release.yml
+++ b/.github/workflows/pipeline_release.yml
@@ -116,11 +116,12 @@ jobs:
     needs: release-publish
     if: ${{ failure() }}
     steps:
-      - name: Slack Notification
-        id: slack
-        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+      - name: Notify Teams on Failure
+        uses: ./.github/workflows/notify_teams.yml
         with:
-          channel-id: "C9W4P9RKM"
-          slack-message: "Nuxeo AI Core ${{ github.workflow }} workflow failed!\n${{ github.event.head_commit.url }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATION_BOT_TOKEN }}
+          message_type: "❌ Nuxeo AI Core ${{ github.workflow }} workflow failed!"
+          workflow_name: ${{ github.workflow }}
+          status: "failure"
+          details: "Release or publish step failed."
+          run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          actor: "${{ github.actor }}"

--- a/.github/workflows/pipeline_release.yml
+++ b/.github/workflows/pipeline_release.yml
@@ -1,5 +1,10 @@
 name: Release Publish
 
+permissions:
+  contents: write
+  packages: write
+  actions: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -121,6 +126,8 @@ jobs:
       details: "Release or publish step failed."
       run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       actor: "${{ github.actor }}"
+    secrets:
+      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
 
   notify-on-success:
     needs: release-publish
@@ -133,3 +140,5 @@ jobs:
       details: "Release and publish steps completed successfully."
       run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       actor: "${{ github.actor }}"
+    secrets:
+      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}

--- a/.github/workflows/pipeline_release.yml
+++ b/.github/workflows/pipeline_release.yml
@@ -73,9 +73,6 @@ jobs:
           mvn -ntp install -DskipInstall
           git push origin v${releasedVersion}
           git push origin release-v${releasedVersion}
-      - name: Force Failure for Notification Test
-        run: exit 1
-
       - name: Archive packages
         uses: actions/upload-artifact@v2
         with:
@@ -122,5 +119,17 @@ jobs:
       workflow_name: ${{ github.workflow }}
       status: "failure"
       details: "Release or publish step failed."
+      run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      actor: "${{ github.actor }}"
+
+  notify-on-success:
+    needs: release-publish
+    if: ${{ !failure() }}
+    uses: ./.github/workflows/notify_teams.yml
+    with:
+      message_type: "✅ Nuxeo AI Core ${{ github.workflow }} workflow succeeded!"
+      workflow_name: ${{ github.workflow }}
+      status: "success"
+      details: "Release and publish steps completed successfully."
       run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       actor: "${{ github.actor }}"

--- a/.github/workflows/pipeline_release.yml
+++ b/.github/workflows/pipeline_release.yml
@@ -73,6 +73,8 @@ jobs:
           mvn -ntp install -DskipInstall
           git push origin v${releasedVersion}
           git push origin release-v${releasedVersion}
+      - name: Force Failure for Notification Test
+        run: exit 1
 
       - name: Archive packages
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This pull request updates the CI/CD notification system to use Microsoft Teams instead of Slack for workflow failure alerts, and introduces test steps to force workflow failures for notification testing purposes. The changes affect both the build/test and release pipelines, and add a new workflow for sending Teams notifications.

**Notification system migration:**

* Replaces Slack notifications with a new Teams notification workflow, calling `notify_teams.yml` on workflow failures in both `build_and_test.yml` and `pipeline_release.yml`. The Teams notification includes workflow details, actor, and a link to the run. [[1]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L161-R171) [[2]](diffhunk://#diff-4cd861890a330dd4127ed5aed1c5fed5fb94dc4b77b01d6f4488eaf023032414L119-R129)
* Adds the new reusable workflow file `notify_teams.yml`, which sends formatted adaptive card notifications to a Teams channel via webhook.

**Testing notification delivery:**

* Adds a "Force Failure for Notification Test" step (`exit 1`) to both the build and release pipelines to simulate workflow failures and trigger notifications. [[1]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2R120-R121) [[2]](diffhunk://#diff-4cd861890a330dd4127ed5aed1c5fed5fb94dc4b77b01d6f4488eaf023032414R76-R77)